### PR TITLE
vespa bucket credentials removed

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,9 @@
 # Release-Notes
+
+## Sprint 20 (13.11.2024 - 03.12.2024)
+### Entfernt
+- Vespa Bucket Credentials entfernt
+
 ## Sprint 15 (30.07.2024 - 20.08.2024)
 ### Entfernt
 - Demo Umgebung

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,9 +26,6 @@ mobidam:
       tenant-default:
         access-key-env-var: MOBIDAM_ACCESS_KEY
         secret-key-env-var: MOBIDAM_SECRET_KEY
-      int-pitprojektmdask-vespa:
-        access-key-env-var: MOBIDAM_PITPROJEKTMDASK_ACCESS_KEY
-        secret-key-env-var: MOBIDAM_PITPROJEKTMDASK_SECRET_KEY
 
 spring:
   application:


### PR DESCRIPTION
## Pull Request

### Description

Extra bucket credentials removed because bucket has moved to default tenant.

### Reference

Issues: MDAS-1163

### Definition of Done
*Advice: Unchecked checkboxes are not accepted by the build pipeline. Cross out any non-relevant item by using '~~'.*

- [x] Acceptance criteria are met
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification)
~[ ] Frontend is locally smoke-tested~
~[ ] Board is updated~ Waiting for FME
- [x] Infrastructure is adjusted

Please delete all side branches after merging.
